### PR TITLE
Fix memory leak

### DIFF
--- a/packages/core/src/observables/observableObject.ts
+++ b/packages/core/src/observables/observableObject.ts
@@ -91,7 +91,7 @@ export const extendObservable = <T extends object, E extends object>(
   return observableObject as unknown as T & E;
 };
 
-const explicitAnnotations = new Map<any, Set<PropertyKey>>();
+const explicitAnnotations = new WeakMap<any, Set<PropertyKey>>();
 
 const annotateObject = <T extends object, E extends object>(
   observableObject: T,


### PR DESCRIPTION
* Uses a WeakMap so that annotations are disposed with their objects
* removes a closure that was unintentionally causing prototypes to retain an instance in memory